### PR TITLE
Jules first edit

### DIFF
--- a/architect.py
+++ b/architect.py
@@ -1,8 +1,10 @@
 import google.generativeai as genai, os
+import markdown2
 genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
 
 def ArchitectAgent(state):
     model = genai.GenerativeModel("gemini-2.0-flash")
     response = model.generate_content(f"You are a software architect. Here's the PM breakdown:\n\n{state['input']}")
     text = response.text
-    return {"__next__": "Frontend", "input": text, "architect_output": text}
+    html_output = markdown2.markdown(text)
+    return {"__next__": "Frontend", "input": html_output, "architect_output": html_output}

--- a/frontend.py
+++ b/frontend.py
@@ -1,7 +1,9 @@
 import google.generativeai as genai, os
+import markdown2
 genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
 
 def FrontendAgent(state):
     model = genai.GenerativeModel("gemini-2.0-flash")
     response = model.generate_content(f"You are the frontend dev. Here's the architect's plan:\n\n{state['input']}")
-    return {"frontend_output": response.text}
+    html_output = markdown2.markdown(response.text)
+    return {"frontend_output": html_output}

--- a/pm.py
+++ b/pm.py
@@ -1,8 +1,10 @@
 import google.generativeai as genai, os
+import markdown2
 genai.configure(api_key=os.getenv("GEMINI_API_KEY"))
 
 def PMAgent(state):
     model = genai.GenerativeModel("gemini-2.0-flash")
     response = model.generate_content(f"You are a PM. Break this down:\n\n{state['input']}")
     text = response.text
-    return {"__next__": "Architect", "input": text, "pm_output": text}
+    html_output = markdown2.markdown(text)
+    return {"__next__": "Architect", "input": html_output, "pm_output": html_output}

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,67 @@
+import unittest
+from unittest import mock
+import markdown2
+
+# Adjust imports based on your project structure
+# Assuming agent files are in the root directory for now
+from pm import PMAgent
+from architect import ArchitectAgent
+from frontend import FrontendAgent
+
+class TestFormatting(unittest.TestCase):
+
+    @mock.patch('google.generativeai.GenerativeModel')
+    def test_pm_agent_formatting(self, MockGenerativeModel):
+        # Configure the mock
+        mock_model_instance = MockGenerativeModel.return_value
+        mock_response = mock.Mock()
+        markdown_text = "# Test Header\n*italic text*\n**bold text**\n- Item 1\n- Item 2"
+        mock_response.text = markdown_text
+        mock_model_instance.generate_content.return_value = mock_response
+
+        # Call the agent
+        state = {"input": "Test input for PM"}
+        result = PMAgent(state)
+
+        # Assertions
+        expected_html = markdown2.markdown(markdown_text)
+        self.assertEqual(result["pm_output"], expected_html)
+        self.assertEqual(result["input"], expected_html) # PMAgent also modifies 'input'
+
+    @mock.patch('google.generativeai.GenerativeModel')
+    def test_architect_agent_formatting(self, MockGenerativeModel):
+        # Configure the mock
+        mock_model_instance = MockGenerativeModel.return_value
+        mock_response = mock.Mock()
+        markdown_text = "## Architect Plan\n> Blockquote\n`inline code`"
+        mock_response.text = markdown_text
+        mock_model_instance.generate_content.return_value = mock_response
+
+        # Call the agent
+        state = {"input": "Test input for Architect"}
+        result = ArchitectAgent(state)
+
+        # Assertions
+        expected_html = markdown2.markdown(markdown_text)
+        self.assertEqual(result["architect_output"], expected_html)
+        self.assertEqual(result["input"], expected_html) # ArchitectAgent also modifies 'input'
+
+    @mock.patch('google.generativeai.GenerativeModel')
+    def test_frontend_agent_formatting(self, MockGenerativeModel):
+        # Configure the mock
+        mock_model_instance = MockGenerativeModel.return_value
+        mock_response = mock.Mock()
+        markdown_text = "### Frontend Details\n* List item 1\n* List item 2\n\n```python\nprint('Hello')\n```"
+        mock_response.text = markdown_text
+        mock_model_instance.generate_content.return_value = mock_response
+
+        # Call the agent
+        state = {"input": "Test input for Frontend"}
+        result = FrontendAgent(state)
+
+        # Assertions
+        expected_html = markdown2.markdown(markdown_text)
+        self.assertEqual(result["frontend_output"], expected_html)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The raw text responses from the generative AI model used by the PM, Architect, and Frontend agents could include markdown formatting that was not being rendered correctly.

This change addresses the issue by:
- Modifying `PMAgent`, `ArchitectAgent`, and `FrontendAgent` to convert their `response.text` from markdown to HTML using the `markdown2` library.
- Ensuring that the `input` fields passed between agents and the final `*_output` fields are all HTML formatted.
- Adding unit tests for each agent to verify the markdown to HTML conversion for various markdown syntax (headers, lists, bold, italics). The tests mock the generative model's response and assert the correctness of the HTML output.

The agent outputs should now be correctly formatted as HTML.